### PR TITLE
Add auto-reviewer workflow for @navi-04 - closes#135

### DIFF
--- a/.github/workflows/assign-reviewer.yml
+++ b/.github/workflows/assign-reviewer.yml
@@ -1,24 +1,22 @@
-name: Auto Assign Multiple Reviewers
+name: Auto-Assign Navi-04 as Reviewer
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review]
+  pull_request:
+    types: [opened, ready_for_review]
 
 jobs:
-  add-reviewers:
+  assign-reviewer:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
-      - name: Assign reviewers
-        uses: actions/github-script@v7
+      - name: Assign @navi-04 as reviewer
+        uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const reviewers = ["navi-04"]; //  reviewers
+            const reviewer = 'navi-04';
+            const prNumber = context.payload.pull_request.number;
             await github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              reviewers
+              pull_number: prNumber,
+              reviewers: [reviewer]
             });


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically assigns @navi-04 as a reviewer for every pull request opened in this repository

The workflow is triggered whenever:
A pull request is opened, draft pull request is marked ready for review